### PR TITLE
✨ Add New Speakers Page with Components and Styling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,13 +1,14 @@
-import React from "react";
 import { Route, Routes } from "react-router-dom";
 import Home from "./pages/home/Home";
 import Headphones from "./pages/headphones/Headphones";
+import Speakers from "./pages/speakers/Speakers";
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Home />} />
       <Route path="/headphones" element={<Headphones />} />
+      <Route path="/speakers" element={<Speakers />} />
     </Routes>
   );
 }

--- a/src/components/products/Product.jsx
+++ b/src/components/products/Product.jsx
@@ -1,6 +1,6 @@
-import { theme } from "../../../theme/theme";
+import { theme } from "../../theme/theme";
 import { styled } from "styled-components";
-import PrimaryButton from "../../../components/buttons/PrimaryButton";
+import PrimaryButton from "../../components/buttons/PrimaryButton";
 
 export default function Product({
   className,

--- a/src/pages/headphones/Headphones.jsx
+++ b/src/pages/headphones/Headphones.jsx
@@ -1,7 +1,7 @@
 import { styled } from "styled-components";
 import Header from "../../components/header/Header";
 import TitlePage from "../../components/page-title/TitlePage";
-import Product from "./products/Product";
+import Product from "../../components/products/Product";
 import Categories from "../../components/categories/Categories";
 import About from "../../components/about/About";
 import Footer from "../../components/footer/Footer";

--- a/src/pages/headphones/Headphones.jsx
+++ b/src/pages/headphones/Headphones.jsx
@@ -94,4 +94,10 @@ const HeadphonesStyled = styled.div`
       }
     }
   }
+
+  @media (max-width: 480px) {
+    main {
+      margin-top: 64px;
+    }
+  }
 `;

--- a/src/pages/speakers/Speakers.jsx
+++ b/src/pages/speakers/Speakers.jsx
@@ -1,0 +1,9 @@
+import { styled } from "styled-components";
+
+export default function Speakers() {
+  return <div>Speakers</div>;
+}
+
+const SpeakersStyled = styled.div`
+  /*  */
+`;

--- a/src/pages/speakers/Speakers.jsx
+++ b/src/pages/speakers/Speakers.jsx
@@ -1,9 +1,94 @@
 import { styled } from "styled-components";
+import TitlePage from "../../components/page-title/TitlePage";
+import Header from "../../components/header/Header";
+import Product from "../../components/products/Product";
+import Categories from "../../components/categories/Categories";
+import About from "../../components/about/About";
+import Footer from "../../components/footer/Footer";
 
 export default function Speakers() {
-  return <div>Speakers</div>;
+  return (
+    <SpeakersStyled>
+      <Header />
+      <TitlePage label={"Seapkers"} />
+      <main>
+        <Product
+          subtitle={"New Product"}
+          title={"ZX9 Speaker"}
+          description={
+            "Upgrade your sound system with the all new ZX9 active speaker. It’s a bookshelf speaker system that offers truly wireless connectivity -- creating new possibilities for more pleasing and practical audio setups."
+          }
+          labelButton={"See product"}
+          desktopImage="/assets/shared/desktop/image-zx9-speaker.jpg"
+          tabletImage={"/assets/shared/tablet/image-zx9-speaker.jpg"}
+          mobileImage={"/assets/shared/mobile/image-zx9-speaker.jpg"}
+          imageAlt={"ZX9 Speaker"}
+        />
+        <Product
+          className={"reverse margin-bottom"}
+          title={"ZX7 Speaker"}
+          description={
+            "Stream high quality sound wirelessly with minimal loss. The ZX7 bookshelf speaker uses high-end audiophile components that represents the top of the line powered speakers for home or studio use."
+          }
+          labelButton={"See product"}
+          desktopImage="/assets/shared/desktop/image-zx7-speaker.jpg"
+          tabletImage={"/assets/shared/tablet/image-zx7-speaker.jpg"}
+          mobileImage={"/assets/shared/mobile/image-zx7-speaker.jpg"}
+          imageAlt={"ZX7 Speaker"}
+        />
+        <Categories />
+        <About className={"margin-top-about"} />
+      </main>
+      <Footer />
+    </SpeakersStyled>
+  );
 }
 
 const SpeakersStyled = styled.div`
-  /*  */
+  main {
+    margin: 0 13.5%; // to review
+    margin-top: 160px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    h2 {
+      margin-right: 30%;
+    }
+
+    .reverse {
+      flex-direction: row-reverse;
+    }
+    .margin-bottom {
+      margin-bottom: 40px;
+    }
+  }
+
+  @media (max-width: 768px) {
+    main {
+      margin-top: 120px;
+
+      span {
+        transform: translateX(10px);
+      }
+      h2 {
+        margin: 0px 10%;
+      }
+      .reverse {
+        flex-direction: column;
+      }
+      .margin-top-categories {
+        margin-top: 140px;
+      }
+      .margin-top-about {
+        margin-top: 70px;
+      }
+    }
+  }
+
+  @media (max-width: 480px) {
+    main {
+      margin-top: 64px;
+    }
+  }
 `;


### PR DESCRIPTION
## 🎉 Nouvelle Fonctionnalité: Page Speakers

Cette Pull Request introduit une toute nouvelle page "Speakers" dans l'application. Voici les détails des ajouts :

### 📦 Composants
- `TitlePage` pour le titre de la page.
- `Product` pour afficher les produits ZX9 et ZX7.
- `Categories` pour montrer les différentes catégories de produits.
- `About` pour une section informative.
- `Footer` pour le pied de page.

### 🎨 Style CSS
- Utilisation de `styled-components` pour un style CSS modulaire et réutilisable.
- Responsive design avec des media queries pour les tablettes et les mobiles.

### 🛠 Structure du Code
- Organisation du code en composants réutilisables pour une meilleure maintenabilité.
- Utilisation de props pour passer des données aux composants.

### 📸 Images
- Images responsives pour les produits ZX9 et ZX7 pour les versions desktop, tablette, et mobile.

### 📝 À Faire
- [ ] Revue de code
- [ ] Tests unitaires

Merci de prendre le temps de revoir cette Pull Request. Tous les commentaires et suggestions sont les bienvenus !
